### PR TITLE
fix potential crash

### DIFF
--- a/addons/gdLinter/gdLinter.gd
+++ b/addons/gdLinter/gdLinter.gd
@@ -102,7 +102,7 @@ func on_resource_saved(resource: Resource) -> void:
 	# Workaround until unique name bug is fixed
 	# https://github.com/Scony/godot-gdscript-toolkit/issues/284
 	# Hope I won't break other stuff with it
-	if output_array[0] == "Line ":
+	if output_array.size() and output_array[0] == "Line ":
 		printerr("gdLint Error: ", output_array, "\n File can't be linted!")
 		return
 	


### PR DESCRIPTION
Hey, thanks for the work!

I was having issues with version 2.0.0 due to Windows, I've seen you've fixed that issue with unpublished 2.0.1, thanks for that!

Also, while I was debugging through that issue, I was also having empty `output_array` which was causing crash because you were trying to check the first index without checking beforehand if it's filled this will fix any potential problems alike.