### PR TITLE
Adding max_returns rule

### DIFF
--- a/addons/gdLinter/Settings/ignore.gd
+++ b/addons/gdLinter/Settings/ignore.gd
@@ -31,6 +31,7 @@ extends Resource
 @export_group("Design Checks")
 @export var _max_public_methods: bool = false
 @export var _function_arguments_number: bool = false
+@export var _max_returns: bool = false
 
 @export_group("Format Checks")
 @export var _max_file_lines: bool = false

--- a/addons/gdLinter/Settings/ignore.tres
+++ b/addons/gdLinter/Settings/ignore.tres
@@ -27,6 +27,7 @@ _private_method_call = false
 _class_definitions_order = false
 _max_public_methods = false
 _function_arguments_number = false
+_max_returns = false
 _max_file_lines = false
 _trailing_whitespace = false
 _max_line_length = false


### PR DESCRIPTION
max_rules trigger on gdscript_formatter plugin and gdlinter threw an error not knowing about the rule.

- add max_rules to ignore.gd/ignore.tres for it to be recognized and can be ignorable by player