### PR TITLE
Add optional Project Settings to configure gdlint

### DIFF
--- a/addons/gdLinter/gdLinter.gd
+++ b/addons/gdLinter/gdLinter.gd
@@ -169,6 +169,11 @@ func get_current_editor() -> CodeEdit:
 
 
 func get_gdlint_path() -> String:
+	var project_gdlint_path: String = ProjectSettings.get_setting("debug/settings/Tools/gdlint_path", "")
+	
+	if(project_gdlint_path.length()):
+		return project_gdlint_path
+
 	if OS.get_name() == "Windows":
 		return "gdlint"
 	

--- a/addons/gdLinter/gdLinter.gd
+++ b/addons/gdLinter/gdLinter.gd
@@ -28,6 +28,12 @@ var _gdlint_path: String
 
 
 func _enter_tree() -> void:
+	var project_gdlint_enabled: bool = ProjectSettings.get_setting("debug/settings/Tools/gdlint_enabled", true)
+	
+	if(! project_gdlint_enabled):
+		print_rich("[color=yellow]Loading GDLint Plugin [u]disabled[/u] in [b]Project Settings -> Debug -> Tools[/b][/color]")
+		return
+
 	# install the GDLint dock
 	_dock_ui = DockScene.instantiate()
 	_dock_ui.gd_linter = self


### PR DESCRIPTION
I am running on macOS, and found the `get_gdlint_path()` function in `addons/gdLinter/gdLinter.gd` to be insufficient for detecting my version of gdlint. After looking at a few solutions, it appears that an optional set of settings was in order.

This change depends on adding two new keys to the Project Settings after installing gdlint. I'm not sure if there is a way to automation this with the plugin at startup, if so, I would like to clean this up further.

The two new settings to add:

- `debug/settings/Tools/gdlint_enabled` with a type of `bool`
  - if the key is missing, this code defaults to treating it as enabled.
- `debug/settings/Tools/gdlint_path` with a type of `String`
  - If the key is missing or no path provided it is ignored and classic logic is used
  
A quick video of adding these settings (it wasn't apparent to me the first time): https://share.cleanshot.com/dn2ZCnYy

**NOTE:** You need to have `Advanced Settings` enabled in Project Settings to see the needed features.